### PR TITLE
Fix broken links in the search results

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -8,7 +8,7 @@ $(document).ready( function() {
     })
   }
 
-  var API_URL = "https://api.domainr.com/v1/search?client_id=chrome_extension&q="
+  var API_URL = "https://api.domainr.com/v1/search?client_id={your-mashape-key}&q="
     , selected_domain
 
   $("#search-form").submit( function(evt) {

--- a/js/script.js
+++ b/js/script.js
@@ -8,7 +8,7 @@ $(document).ready( function() {
     })
   }
 
-  var API_URL = "https://api.domainr.com/v1/search?client_id={your-mashape-key}&q="
+  var API_URL = "https://api.domainr.com/v1/search?client_id=chrome_extension&q="
     , selected_domain
 
   $("#search-form").submit( function(evt) {
@@ -84,7 +84,7 @@ $(document).ready( function() {
       var val = $(this).val();
       var $selected = $(".selected");
       if ($selected.length) {
-        var url = $(".selected a").attr('href') + "/with/" + $(".selected a").text();
+        var url = $(".selected a").attr('href');
         createChromeTab(url);
       }
       return false;
@@ -99,8 +99,8 @@ $(document).ready( function() {
   });
 
   $("#results-list li a").live('click', function(ev) {
-    var url = $(this).attr('href')
-    createChromeTab(url)
+    var url = $(this).attr('href');
+    createChromeTab(url);
   });
 
 })

--- a/js/script.js
+++ b/js/script.js
@@ -32,7 +32,7 @@ $(document).ready( function() {
           $("<p id='search-query'>" + query + "</p>").insertBefore("#results")
         }
         $.each(response.results,function(i, result){
-          $("#results-list").append("<li class='" + result.availability + "'><a href='https://domainr.com/" + query + "'><span class='bg'></span><span class='domain'>" + result.domain + "</span></a></li>")
+          $("#results-list").append("<li class='" + result.availability + "'><a href='https://domainr.com/" + result.domain + '?q=' + query + "'><span class='bg'></span><span class='domain'>" + result.domain + "</span></a></li>")
         })
         $("#loader").css('visibility', 'hidden');     // hide the spinny thingy.
       });
@@ -99,7 +99,7 @@ $(document).ready( function() {
   });
 
   $("#results-list li a").live('click', function(ev) {
-    var url = $(this).attr('href') + "/with/" + $(this).text()
+    var url = $(this).attr('href')
     createChromeTab(url)
   });
 


### PR DESCRIPTION
Currently, when you click on the search results, you see the following:

![domainr-2](https://cloud.githubusercontent.com/assets/64734/9837072/8623008c-5a33-11e5-930e-2f97467695cc.png)

This pull request fixes the URL generation to match the web app version.

P.S. Didn't think it would be so quick, @case. I wouldn't send you the email then.
P.P.S. I think it's your prerogative to bump up the version in the manifest, so I left it untouched.