### PR TITLE
Prevent 2 tabs from opening on a middle/ctrl click

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -101,6 +101,7 @@ $(document).ready( function() {
   $("#results-list li a").live('click', function(ev) {
     var url = $(this).attr('href') + "/with/" + $(this).text()
     createChromeTab(url)
+    ev.preventDefault();
   });
 
 })


### PR DESCRIPTION
If you do a search now and use a middle mouse button or hold the Ctrl down, two tabs with the results will open:

![domainr-4](https://cloud.githubusercontent.com/assets/64734/9838385/c0a27840-5a5c-11e5-9a4c-db7d0662c394.png)

As there is a new tab opening code, the default event has to be suppressed.